### PR TITLE
Turn Hittable to enum to avoid dynamic dispatch

### DIFF
--- a/src/hittable.rs
+++ b/src/hittable.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use crate::{material::Material, Ray};
+use crate::{material::Material, sphere::Sphere, Ray};
 use cliffy::*;
 
 pub struct HitRecord {
@@ -42,6 +42,14 @@ impl HitRecord {
     }
 }
 
-pub trait Hittable {
-    fn hit(&self, r: &Ray, t_min: f32, t_max: f32) -> Option<HitRecord>;
+pub enum Hittable {
+    Sphere(Sphere),
+}
+
+impl Hittable {
+    pub fn hit(&self, r: &Ray, t_min: f32, t_max: f32) -> Option<HitRecord> {
+        match &self {
+            Hittable::Sphere(sphere) => sphere.hit(r, t_min, t_max),
+        }
+    }
 }

--- a/src/hittable_list.rs
+++ b/src/hittable_list.rs
@@ -2,11 +2,11 @@ use crate::{hittable::*, ray::Ray};
 
 #[derive(Default)]
 pub struct HittableList {
-    pub objects: Vec<Box<dyn Hittable>>,
+    pub objects: Vec<Hittable>,
 }
 
 impl HittableList {
-    pub fn new(object: Box<dyn Hittable>) -> Self {
+    pub fn new(object: Hittable) -> Self {
         Self {
             objects: vec![object],
         }
@@ -16,13 +16,11 @@ impl HittableList {
         self.objects.clear();
     }
 
-    pub fn add(&mut self, object: Box<dyn Hittable>) {
+    pub fn add(&mut self, object: Hittable) {
         self.objects.push(object);
     }
-}
 
-impl Hittable for HittableList {
-    fn hit(&self, r: &Ray, t_min: f32, t_max: f32) -> Option<HitRecord> {
+    pub fn hit(&self, r: &Ray, t_min: f32, t_max: f32) -> Option<HitRecord> {
         let mut temp_rec = None;
         let mut closest_so_far = t_max;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ fn clamp(x: f32, min: f32, max: f32) -> f32 {
     result
 }
 
-fn ray_color(r: &Ray, world: &dyn Hittable, depth: u32) -> Vec3 {
+fn ray_color(r: &Ray, world: &HittableList, depth: u32) -> Vec3 {
     if depth == 0 {
         return Vec3::zero();
     }
@@ -85,7 +85,7 @@ fn random_scene() -> HittableList {
     let mut world = HittableList::default();
 
     let ground_material = Rc::new(Lambertian::new(Vec3::new(0.5, 0.5, 0.5)));
-    world.add(Box::new(Sphere::new(
+    world.add(Hittable::Sphere(Sphere::new(
         Vec3::new(0.0, -1000.0, 0.0),
         1000.0,
         ground_material.clone(),
@@ -108,7 +108,7 @@ fn random_scene() -> HittableList {
                     albedo.x *= random_albedo.x;
                     albedo.y *= random_albedo.y;
                     albedo.z *= random_albedo.z;
-                    world.add(Box::new(Sphere::new(
+                    world.add(Hittable::Sphere(Sphere::new(
                         center,
                         0.2,
                         Rc::new(Lambertian::new(albedo)),
@@ -117,14 +117,14 @@ fn random_scene() -> HittableList {
                     // metal
                     let albedo = utilities::random_vec3_between(0.5, 1.0);
                     let fuzz = utilities::random_between(0.0, 0.5);
-                    world.add(Box::new(Sphere::new(
+                    world.add(Hittable::Sphere(Sphere::new(
                         center,
                         0.2,
                         Rc::new(Metal::new(albedo, fuzz)),
                     )));
                 } else {
                     // glass
-                    world.add(Box::new(Sphere::new(
+                    world.add(Hittable::Sphere(Sphere::new(
                         center,
                         0.2,
                         Rc::new(Dielectric::new(1.5)),
@@ -135,21 +135,21 @@ fn random_scene() -> HittableList {
     }
 
     let material1 = Rc::new(Dielectric::new(1.5));
-    world.add(Box::new(Sphere::new(
+    world.add(Hittable::Sphere(Sphere::new(
         Vec3::new(0.0, 1.0, 0.0),
         1.0,
         material1,
     )));
 
     let material2 = Rc::new(Lambertian::new(Vec3::new(0.4, 0.2, 0.1)));
-    world.add(Box::new(Sphere::new(
+    world.add(Hittable::Sphere(Sphere::new(
         Vec3::new(-4.0, 1.0, 0.0),
         1.0,
         material2,
     )));
 
     let material3 = Rc::new(Metal::new(Vec3::new(0.7, 0.6, 0.5), 0.0));
-    world.add(Box::new(Sphere::new(
+    world.add(Hittable::Sphere(Sphere::new(
         Vec3::new(4.0, 1.0, 0.0),
         1.0,
         material3,
@@ -161,10 +161,10 @@ fn random_scene() -> HittableList {
 fn main() {
     // Image
     let aspect_ratio = 16.0 / 9.0;
-    let image_width = 1280;
+    let image_width = 360;
     let image_height = (image_width as f32 / aspect_ratio) as u32;
-    let samples_per_pixel = 500;
-    let max_depth = 50;
+    let samples_per_pixel = 5;
+    let max_depth = 5;
 
     let mut image = DynamicImage::new_rgb8(image_width, image_height);
 

--- a/src/sphere.rs
+++ b/src/sphere.rs
@@ -16,10 +16,8 @@ impl Sphere {
             material,
         }
     }
-}
 
-impl Hittable for Sphere {
-    fn hit(&self, r: &Ray, t_min: f32, t_max: f32) -> Option<HitRecord> {
+    pub fn hit(&self, r: &Ray, t_min: f32, t_max: f32) -> Option<HitRecord> {
         let oc = r.origin - self.center;
         let a = r.direction.mag_sq();
         let half_b = oc.dot(r.direction);


### PR DESCRIPTION
Make Hittable an enum based on suggestion from this tweet.
<blockquote class="twitter-tweet"><p lang="en" dir="ltr">You could get away from storing dynamic trait objects by turning Hittable into an enum and having a Sphere variant with your Sphere inner struct. This would make it statically dispatched.</p>&mdash; Robert Blanchet, Jr. (@xgalaxy) <a href="https://twitter.com/xgalaxy/status/1472633690131812361?ref_src=twsrc%5Etfw">December 19, 2021</a></blockquote>